### PR TITLE
Notifications: Handle a failure without a failure message

### DIFF
--- a/src/targets/chat.js
+++ b/src/targets/chat.js
@@ -111,7 +111,7 @@ function getFailureDetails(suite) {
   for (let i = 0; i < cases.length; i++) {
     const test_case = cases[i];
     if (test_case.status === 'FAIL') {
-      text += `<b>Test</b>: ${test_case.name}<br><b>Error</b>: ${truncate(test_case.failure, 150)}<br><br>`;
+      text += `<b>Test</b>: ${test_case.name}<br><b>Error</b>: ${truncate(test_case.failure ?? 'N/A', 150)}<br><br>`;
     }
   }
   return text;

--- a/src/targets/slack.js
+++ b/src/targets/slack.js
@@ -129,7 +129,7 @@ function getFailureDetails(suite) {
   for (let i = 0; i < cases.length; i++) {
     const test_case = cases[i];
     if (test_case.status === 'FAIL') {
-      text += `*Test*: ${test_case.name}\n*Error*: ${truncate(test_case.failure, 150)}\n\n`;
+      text += `*Test*: ${test_case.name}\n*Error*: ${truncate(test_case.failure ?? 'N/A', 150)}\n\n`;
     }
   }
   return {

--- a/src/targets/teams.js
+++ b/src/targets/teams.js
@@ -183,7 +183,7 @@ function getFailureDetailsFactSets(suite) {
           },
           {
             "title": "Error:",
-            "value": truncate(test_case.failure, 150)
+            "value": truncate(test_case.failure ?? 'N/A', 150)
           }
         ]
       });


### PR DESCRIPTION
The message attribute of `<failure>` is optional and some tools print the message in the textContent. We shouldn't output `undefined` if it's not present.

See https://github.com/test-results-reporter/parser/issues/73 for the root issue