### PR TITLE
Fixing stale package version in --version

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -6,9 +6,10 @@ const sade = require('sade');
 const prog = sade('testbeats');
 const { PublishCommand } = require('./commands/publish.command');
 const logger = require('./utils/logger');
+const pkg = require('../package.json');
 
 prog
-  .version('2.0.4')
+  .version(pkg.version)
   .option('-c, --config', 'path to config file')
   .option('-l, --logLevel', 'Log Level', "INFO")
   .option('--api-key', 'api key')


### PR DESCRIPTION
Summary:

- Version was hardcoded in `cli.js`, resulting in stale version being printed for `testbeats -v`
- use npm package version 


Before:
<img width="204" alt="image" src="https://github.com/user-attachments/assets/39b632cf-e064-450e-8785-e59624b87a21">


After:
<img width="167" alt="image" src="https://github.com/user-attachments/assets/436a86ce-dca0-4f48-a53f-7950f6755d6b">
