### PR TITLE
feat: testbeats config generation command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ results
 override-config*.json
 
 .testbeats
+.testbeats.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,6 +2593,11 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/semver": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
@@ -4813,6 +4818,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "7.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.6",
       "license": "ISC",
       "dependencies": {
+        "@inquirer/prompts": "^7.1.0",
         "async-retry": "^1.3.3",
         "dotenv": "^16.4.5",
         "form-data-lite": "^1.0.3",
@@ -108,6 +109,257 @@
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
       "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.2.tgz",
+      "integrity": "sha512-+gznPl8ip8P8HYHYecDtUtdsh1t2jvb+sWCD72GAiZ9m45RqwrLmReDaqdC0umQfamtFXVRoMVJ2/qINKGm9Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
+      "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
+      "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.1.0.tgz",
+      "integrity": "sha512-K1gGWsxEqO23tVdp5MT3H799OZ4ER1za7Dlc8F4um0W7lwSv0KGR/YyrUEyimj0g7dXZd8XknM/5QA2/Uy+TbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.2.tgz",
+      "integrity": "sha512-WdgCX1cUtinz+syKyZdJomovULYlKUWZbVYZzhf+ZeeYf4htAQ3jLymoNs3koIAKfZZl3HUBb819ClCBfyznaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
+      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.2.tgz",
+      "integrity": "sha512-yCLCraigU085EcdpIVEDgyfGv4vBiE4I+k1qRkc9C5dMjWF42ADMGy1RFU94+eZlz4YlkmFsiyHZy0W1wdhaNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.2.tgz",
+      "integrity": "sha512-MKQhYofdUNk7eqJtz52KvM1dH6R93OMrqHduXCvuefKrsiMjHiMwjc3NZw5Imm2nqY7gWd9xdhYrtcHMJQZUxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.2.tgz",
+      "integrity": "sha512-tQXGSu7IO07gsYlGy3VgXRVsbOWqFBMbqAUrJSc1PDTQQ5Qdm+QVwkP0OC0jnUZ62D19iPgXOMO+tnWG+HhjNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.1.0.tgz",
+      "integrity": "sha512-5U/XiVRH2pp1X6gpNAjWOglMf38/Ys522ncEHIKT1voRUvSj/DQnR22OVxHnwu5S+rCFaUiPQ57JOtMFQayqYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.0.2",
+        "@inquirer/confirm": "^5.0.2",
+        "@inquirer/editor": "^4.1.0",
+        "@inquirer/expand": "^4.0.2",
+        "@inquirer/input": "^4.0.2",
+        "@inquirer/number": "^3.0.2",
+        "@inquirer/password": "^4.0.2",
+        "@inquirer/rawlist": "^4.0.2",
+        "@inquirer/search": "^3.0.2",
+        "@inquirer/select": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.2.tgz",
+      "integrity": "sha512-3XGcskMoVF8H0Dl1S5TSZ3rMPPBWXRcM0VeNVsS4ByWeWjSeb0lPqfnBg6N7T0608I1B2bSVnbi2cwCrmOD1Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.2.tgz",
+      "integrity": "sha512-Zv4FC7w4dJ13BOJfKRQCICQfShinGjb1bCEIHxTSnjj2telu3+3RHwHubPG9HyD4aix5s+lyAMEK/wSFD75HLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.2.tgz",
+      "integrity": "sha512-uSWUzaSYAEj0hlzxa1mUB6VqrKaYx0QxGBLZzU4xWFxaSyGaXxsSE4OSOwdU24j0xl8OajgayqFXW0l2bkl2kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
+      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -309,6 +561,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "dev": true,
@@ -329,9 +590,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -339,7 +613,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -607,6 +880,11 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
     "node_modules/charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -647,6 +925,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "dev": true,
@@ -659,7 +945,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -670,7 +955,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -832,7 +1116,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -869,6 +1152,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fast-glob": {
@@ -1163,6 +1459,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "dev": true,
@@ -1280,7 +1587,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1733,6 +2039,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -1792,6 +2106,14 @@
       "license": "ISC",
       "dependencies": {
         "klona": "^2.0.4"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/p-is-promise": {
@@ -2317,7 +2639,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -2401,7 +2722,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2429,7 +2749,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2593,6 +2912,17 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "dev": true,
@@ -2647,6 +2977,23 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -2811,6 +3158,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -2861,6 +3220,164 @@
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
       "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true
+    },
+    "@inquirer/checkbox": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.2.tgz",
+      "integrity": "sha512-+gznPl8ip8P8HYHYecDtUtdsh1t2jvb+sWCD72GAiZ9m45RqwrLmReDaqdC0umQfamtFXVRoMVJ2/qINKGm9Tg==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/confirm": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
+      "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
+      }
+    },
+    "@inquirer/core": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
+      "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
+      "requires": {
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "dependencies": {
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@inquirer/editor": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.1.0.tgz",
+      "integrity": "sha512-K1gGWsxEqO23tVdp5MT3H799OZ4ER1za7Dlc8F4um0W7lwSv0KGR/YyrUEyimj0g7dXZd8XknM/5QA2/Uy+TbA==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
+        "external-editor": "^3.1.0"
+      }
+    },
+    "@inquirer/expand": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.2.tgz",
+      "integrity": "sha512-WdgCX1cUtinz+syKyZdJomovULYlKUWZbVYZzhf+ZeeYf4htAQ3jLymoNs3koIAKfZZl3HUBb819ClCBfyznaw==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/figures": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
+      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg=="
+    },
+    "@inquirer/input": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.2.tgz",
+      "integrity": "sha512-yCLCraigU085EcdpIVEDgyfGv4vBiE4I+k1qRkc9C5dMjWF42ADMGy1RFU94+eZlz4YlkmFsiyHZy0W1wdhaNg==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
+      }
+    },
+    "@inquirer/number": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.2.tgz",
+      "integrity": "sha512-MKQhYofdUNk7eqJtz52KvM1dH6R93OMrqHduXCvuefKrsiMjHiMwjc3NZw5Imm2nqY7gWd9xdhYrtcHMJQZUxA==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
+      }
+    },
+    "@inquirer/password": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.2.tgz",
+      "integrity": "sha512-tQXGSu7IO07gsYlGy3VgXRVsbOWqFBMbqAUrJSc1PDTQQ5Qdm+QVwkP0OC0jnUZ62D19iPgXOMO+tnWG+HhjNQ==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2"
+      }
+    },
+    "@inquirer/prompts": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.1.0.tgz",
+      "integrity": "sha512-5U/XiVRH2pp1X6gpNAjWOglMf38/Ys522ncEHIKT1voRUvSj/DQnR22OVxHnwu5S+rCFaUiPQ57JOtMFQayqYA==",
+      "requires": {
+        "@inquirer/checkbox": "^4.0.2",
+        "@inquirer/confirm": "^5.0.2",
+        "@inquirer/editor": "^4.1.0",
+        "@inquirer/expand": "^4.0.2",
+        "@inquirer/input": "^4.0.2",
+        "@inquirer/number": "^3.0.2",
+        "@inquirer/password": "^4.0.2",
+        "@inquirer/rawlist": "^4.0.2",
+        "@inquirer/search": "^3.0.2",
+        "@inquirer/select": "^4.0.2"
+      }
+    },
+    "@inquirer/rawlist": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.2.tgz",
+      "integrity": "sha512-3XGcskMoVF8H0Dl1S5TSZ3rMPPBWXRcM0VeNVsS4ByWeWjSeb0lPqfnBg6N7T0608I1B2bSVnbi2cwCrmOD1Yw==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/search": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.2.tgz",
+      "integrity": "sha512-Zv4FC7w4dJ13BOJfKRQCICQfShinGjb1bCEIHxTSnjj2telu3+3RHwHubPG9HyD4aix5s+lyAMEK/wSFD75HLA==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/select": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.2.tgz",
+      "integrity": "sha512-uSWUzaSYAEj0hlzxa1mUB6VqrKaYx0QxGBLZzU4xWFxaSyGaXxsSE4OSOwdU24j0xl8OajgayqFXW0l2bkl2kg==",
+      "requires": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
+      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
+      "requires": {}
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -2997,6 +3514,15 @@
       "version": "2.0.4",
       "dev": true
     },
+    "@types/node": {
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "peer": true,
+      "requires": {
+        "undici-types": "~6.20.0"
+      }
+    },
     "agent-base": {
       "version": "6.0.2",
       "dev": true,
@@ -3010,13 +3536,19 @@
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true
     },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "requires": {
+        "type-fest": "^0.21.3"
+      }
+    },
     "ansi-regex": {
-      "version": "5.0.1",
-      "dev": true
+      "version": "5.0.1"
     },
     "ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -3185,6 +3717,11 @@
         "supports-color": "^7.1.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -3209,6 +3746,11 @@
       "version": "1.1.4",
       "dev": true
     },
+    "cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
+    },
     "cliui": {
       "version": "7.0.4",
       "dev": true,
@@ -3220,14 +3762,12 @@
     },
     "color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.4",
-      "dev": true
+      "version": "1.1.4"
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3329,8 +3869,7 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "dev": true
+      "version": "8.0.0"
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3352,6 +3891,16 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -3538,6 +4087,14 @@
         "debug": "4"
       }
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "ieee754": {
       "version": "1.2.1",
       "dev": true
@@ -3608,8 +4165,7 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "is-glob": {
       "version": "4.0.3",
@@ -3902,6 +4458,11 @@
         }
       }
     },
+    "mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="
+    },
     "napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -3941,6 +4502,11 @@
       "requires": {
         "klona": "^2.0.4"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "p-is-promise": {
       "version": "3.0.0",
@@ -4281,8 +4847,7 @@
     "signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
     "simple-concat": {
       "version": "1.0.1",
@@ -4327,7 +4892,6 @@
     },
     "string-width": {
       "version": "4.2.3",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4347,7 +4911,6 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -4467,6 +5030,14 @@
         }
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "dev": true
@@ -4502,6 +5073,17 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+    },
+    "undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "peer": true
     },
     "universalify": {
       "version": "2.0.0",
@@ -4611,6 +5193,11 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.1.6",
       "license": "ISC",
       "dependencies": {
-        "@inquirer/prompts": "^7.1.0",
         "async-retry": "^1.3.3",
         "dotenv": "^16.4.5",
         "form-data-lite": "^1.0.3",
@@ -17,6 +16,7 @@
         "performance-results-parser": "latest",
         "phin-retry": "^1.0.3",
         "pretty-ms": "^7.0.1",
+        "prompts": "^2.4.2",
         "rosters": "0.0.1",
         "sade": "^1.8.1",
         "test-results-parser": "0.2.5"
@@ -109,257 +109,6 @@
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
       "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true
-    },
-    "node_modules/@inquirer/checkbox": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.2.tgz",
-      "integrity": "sha512-+gznPl8ip8P8HYHYecDtUtdsh1t2jvb+sWCD72GAiZ9m45RqwrLmReDaqdC0umQfamtFXVRoMVJ2/qINKGm9Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
-      "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/editor": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.1.0.tgz",
-      "integrity": "sha512-K1gGWsxEqO23tVdp5MT3H799OZ4ER1za7Dlc8F4um0W7lwSv0KGR/YyrUEyimj0g7dXZd8XknM/5QA2/Uy+TbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1",
-        "external-editor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/expand": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.2.tgz",
-      "integrity": "sha512-WdgCX1cUtinz+syKyZdJomovULYlKUWZbVYZzhf+ZeeYf4htAQ3jLymoNs3koIAKfZZl3HUBb819ClCBfyznaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
-      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/input": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.2.tgz",
-      "integrity": "sha512-yCLCraigU085EcdpIVEDgyfGv4vBiE4I+k1qRkc9C5dMjWF42ADMGy1RFU94+eZlz4YlkmFsiyHZy0W1wdhaNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/number": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.2.tgz",
-      "integrity": "sha512-MKQhYofdUNk7eqJtz52KvM1dH6R93OMrqHduXCvuefKrsiMjHiMwjc3NZw5Imm2nqY7gWd9xdhYrtcHMJQZUxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/password": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.2.tgz",
-      "integrity": "sha512-tQXGSu7IO07gsYlGy3VgXRVsbOWqFBMbqAUrJSc1PDTQQ5Qdm+QVwkP0OC0jnUZ62D19iPgXOMO+tnWG+HhjNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/prompts": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.1.0.tgz",
-      "integrity": "sha512-5U/XiVRH2pp1X6gpNAjWOglMf38/Ys522ncEHIKT1voRUvSj/DQnR22OVxHnwu5S+rCFaUiPQ57JOtMFQayqYA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^4.0.2",
-        "@inquirer/confirm": "^5.0.2",
-        "@inquirer/editor": "^4.1.0",
-        "@inquirer/expand": "^4.0.2",
-        "@inquirer/input": "^4.0.2",
-        "@inquirer/number": "^3.0.2",
-        "@inquirer/password": "^4.0.2",
-        "@inquirer/rawlist": "^4.0.2",
-        "@inquirer/search": "^3.0.2",
-        "@inquirer/select": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/rawlist": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.2.tgz",
-      "integrity": "sha512-3XGcskMoVF8H0Dl1S5TSZ3rMPPBWXRcM0VeNVsS4ByWeWjSeb0lPqfnBg6N7T0608I1B2bSVnbi2cwCrmOD1Yw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/search": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.2.tgz",
-      "integrity": "sha512-Zv4FC7w4dJ13BOJfKRQCICQfShinGjb1bCEIHxTSnjj2telu3+3RHwHubPG9HyD4aix5s+lyAMEK/wSFD75HLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/select": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.2.tgz",
-      "integrity": "sha512-uSWUzaSYAEj0hlzxa1mUB6VqrKaYx0QxGBLZzU4xWFxaSyGaXxsSE4OSOwdU24j0xl8OajgayqFXW0l2bkl2kg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
-      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -561,15 +310,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.20.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "dev": true,
@@ -590,22 +330,9 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -613,6 +340,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -880,11 +608,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
     "node_modules/charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -925,14 +648,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "dev": true,
@@ -945,6 +660,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -955,6 +671,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -1116,6 +833,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -1152,19 +870,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/fast-glob": {
@@ -1459,17 +1164,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "dev": true,
@@ -1587,6 +1281,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1730,6 +1425,14 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/klona": {
@@ -2039,14 +1742,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -2106,14 +1801,6 @@
       "license": "ISC",
       "dependencies": {
         "klona": "^2.0.4"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/p-is-promise": {
@@ -2406,6 +2093,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "dev": true,
@@ -2593,11 +2292,6 @@
         }
       ]
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "node_modules/semver": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
@@ -2644,6 +2338,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -2696,6 +2391,11 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "dev": true,
@@ -2727,6 +2427,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2754,6 +2455,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2917,17 +2619,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "dev": true,
@@ -2982,23 +2673,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -3163,18 +2837,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     }
   },
   "dependencies": {
@@ -3225,164 +2887,6 @@
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
       "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true
-    },
-    "@inquirer/checkbox": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.2.tgz",
-      "integrity": "sha512-+gznPl8ip8P8HYHYecDtUtdsh1t2jvb+sWCD72GAiZ9m45RqwrLmReDaqdC0umQfamtFXVRoMVJ2/qINKGm9Tg==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      }
-    },
-    "@inquirer/confirm": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
-      "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1"
-      }
-    },
-    "@inquirer/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "requires": {
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "dependencies": {
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
-      }
-    },
-    "@inquirer/editor": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.1.0.tgz",
-      "integrity": "sha512-K1gGWsxEqO23tVdp5MT3H799OZ4ER1za7Dlc8F4um0W7lwSv0KGR/YyrUEyimj0g7dXZd8XknM/5QA2/Uy+TbA==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1",
-        "external-editor": "^3.1.0"
-      }
-    },
-    "@inquirer/expand": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.2.tgz",
-      "integrity": "sha512-WdgCX1cUtinz+syKyZdJomovULYlKUWZbVYZzhf+ZeeYf4htAQ3jLymoNs3koIAKfZZl3HUBb819ClCBfyznaw==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1",
-        "yoctocolors-cjs": "^2.1.2"
-      }
-    },
-    "@inquirer/figures": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
-      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg=="
-    },
-    "@inquirer/input": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.2.tgz",
-      "integrity": "sha512-yCLCraigU085EcdpIVEDgyfGv4vBiE4I+k1qRkc9C5dMjWF42ADMGy1RFU94+eZlz4YlkmFsiyHZy0W1wdhaNg==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1"
-      }
-    },
-    "@inquirer/number": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.2.tgz",
-      "integrity": "sha512-MKQhYofdUNk7eqJtz52KvM1dH6R93OMrqHduXCvuefKrsiMjHiMwjc3NZw5Imm2nqY7gWd9xdhYrtcHMJQZUxA==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1"
-      }
-    },
-    "@inquirer/password": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.2.tgz",
-      "integrity": "sha512-tQXGSu7IO07gsYlGy3VgXRVsbOWqFBMbqAUrJSc1PDTQQ5Qdm+QVwkP0OC0jnUZ62D19iPgXOMO+tnWG+HhjNQ==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2"
-      }
-    },
-    "@inquirer/prompts": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.1.0.tgz",
-      "integrity": "sha512-5U/XiVRH2pp1X6gpNAjWOglMf38/Ys522ncEHIKT1voRUvSj/DQnR22OVxHnwu5S+rCFaUiPQ57JOtMFQayqYA==",
-      "requires": {
-        "@inquirer/checkbox": "^4.0.2",
-        "@inquirer/confirm": "^5.0.2",
-        "@inquirer/editor": "^4.1.0",
-        "@inquirer/expand": "^4.0.2",
-        "@inquirer/input": "^4.0.2",
-        "@inquirer/number": "^3.0.2",
-        "@inquirer/password": "^4.0.2",
-        "@inquirer/rawlist": "^4.0.2",
-        "@inquirer/search": "^3.0.2",
-        "@inquirer/select": "^4.0.2"
-      }
-    },
-    "@inquirer/rawlist": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.2.tgz",
-      "integrity": "sha512-3XGcskMoVF8H0Dl1S5TSZ3rMPPBWXRcM0VeNVsS4ByWeWjSeb0lPqfnBg6N7T0608I1B2bSVnbi2cwCrmOD1Yw==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1",
-        "yoctocolors-cjs": "^2.1.2"
-      }
-    },
-    "@inquirer/search": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.2.tgz",
-      "integrity": "sha512-Zv4FC7w4dJ13BOJfKRQCICQfShinGjb1bCEIHxTSnjj2telu3+3RHwHubPG9HyD4aix5s+lyAMEK/wSFD75HLA==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "yoctocolors-cjs": "^2.1.2"
-      }
-    },
-    "@inquirer/select": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.2.tgz",
-      "integrity": "sha512-uSWUzaSYAEj0hlzxa1mUB6VqrKaYx0QxGBLZzU4xWFxaSyGaXxsSE4OSOwdU24j0xl8OajgayqFXW0l2bkl2kg==",
-      "requires": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      }
-    },
-    "@inquirer/type": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
-      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "requires": {}
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -3519,15 +3023,6 @@
       "version": "2.0.4",
       "dev": true
     },
-    "@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
-      "peer": true,
-      "requires": {
-        "undici-types": "~6.20.0"
-      }
-    },
     "agent-base": {
       "version": "6.0.2",
       "dev": true,
@@ -3541,19 +3036,13 @@
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true
     },
-    "ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "requires": {
-        "type-fest": "^0.21.3"
-      }
-    },
     "ansi-regex": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -3722,11 +3211,6 @@
         "supports-color": "^7.1.0"
       }
     },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -3751,11 +3235,6 @@
       "version": "1.1.4",
       "dev": true
     },
-    "cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
-    },
     "cliui": {
       "version": "7.0.4",
       "dev": true,
@@ -3767,12 +3246,14 @@
     },
     "color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.4"
+      "version": "1.1.4",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3874,7 +3355,8 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "8.0.0"
+      "version": "8.0.0",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3896,16 +3378,6 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true
-    },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -4092,14 +3564,6 @@
         "debug": "4"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ieee754": {
       "version": "1.2.1",
       "dev": true
@@ -4170,7 +3634,8 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
@@ -4260,6 +3725,11 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "klona": {
       "version": "2.0.6",
@@ -4463,11 +3933,6 @@
         }
       }
     },
-    "mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="
-    },
     "napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -4507,11 +3972,6 @@
       "requires": {
         "klona": "^2.0.4"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "p-is-promise": {
       "version": "3.0.0",
@@ -4710,6 +4170,15 @@
       "version": "2.0.3",
       "dev": true
     },
+    "prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "pump": {
       "version": "3.0.0",
       "dev": true,
@@ -4819,11 +4288,6 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "semver": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
@@ -4857,7 +4321,8 @@
     "signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true
     },
     "simple-concat": {
       "version": "1.0.1",
@@ -4875,6 +4340,11 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "slash": {
       "version": "3.0.0",
@@ -4902,6 +4372,7 @@
     },
     "string-width": {
       "version": "4.2.3",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4921,6 +4392,7 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -5040,14 +4512,6 @@
         }
       }
     },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
-    },
     "to-fast-properties": {
       "version": "2.0.0",
       "dev": true
@@ -5083,17 +4547,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
-    },
-    "undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "peer": true
     },
     "universalify": {
       "version": "2.0.0",
@@ -5203,11 +4656,6 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
-    },
-    "yoctocolors-cjs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "homepage": "https://testbeats.com",
   "dependencies": {
-    "@inquirer/prompts": "^7.1.0",
     "async-retry": "^1.3.3",
     "dotenv": "^16.4.5",
     "form-data-lite": "^1.0.3",
@@ -54,6 +53,7 @@
     "performance-results-parser": "latest",
     "phin-retry": "^1.0.3",
     "pretty-ms": "^7.0.1",
+    "prompts": "^2.4.2",
     "rosters": "0.0.1",
     "sade": "^1.8.1",
     "test-results-parser": "0.2.5"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "homepage": "https://testbeats.com",
   "dependencies": {
+    "@inquirer/prompts": "^7.1.0",
     "async-retry": "^1.3.3",
     "dotenv": "^16.4.5",
     "form-data-lite": "^1.0.3",

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,22 +9,12 @@ const { GenerateConfigCommand } = require('./commands/generate-config.command');
 const logger = require('./utils/logger');
 const pkg = require('../package.json');
 
-const banner = `
- _____             _    ___                  _         
-(_   _)           ( )_ (  _'\\               ( )_       
-  | |   __    ___ | ,_)| (_) )   __     _ _ | ,_)  ___ 
-  | | /'__'\\/',__)| |  |  _ <' /'__'\\ /'_' )| |  /',__)
-  | |(  ___/\\__, \\| |_ | (_) )(  ___/( (_| || |_ \\__, \\
-  (_)'\\____)(____/'\\__)(____/''\\____)'\\__,_)'\\__)(____/
-  
-                     v${pkg.version}  
-                Config Generation [BETA]
-`
-
 prog
   .version(pkg.version)
   .option('-l, --logLevel', 'Log Level', "INFO")
 
+
+// Command to publish test results
 prog.command('publish')
   .option('-c, --config', 'path to config file')
   .option('--api-key', 'api key')
@@ -54,21 +44,18 @@ prog.command('publish')
     }
   });
 
+// Command to initialize and generate TestBeats Configuration file
 prog.command('init')
   .describe('Generate a TestBeats configuration file')
   .example('init')
   .action(async (opts) => {
-    console.log(banner)
     try {
-      logger.setLevel(opts.logLevel);
-      logger.info(`🚧 Config generation is still in BETA mode, please report any issues at ${pkg.bugs.url}\n`);
-      const generate_command = new GenerateConfigCommand();
+      const generate_command = new GenerateConfigCommand(opts);
       await generate_command.execute();
     } catch (error) {
       if (error.name === 'ExitPromptError') {
         logger.info('😿 Configuration generation was canceled by the user.');
       } else {
-        logger.debug(error.stack)
         throw new Error(`❌ Error in generating configuration file: ${error.message}`)
       }
       process.exit(1);

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,6 @@
 require('dotenv').config();
 
 const sade = require('sade');
-const { ExitPromptError } = require('@inquirer/prompts');
 
 const prog = sade('testbeats');
 const { PublishCommand } = require('./commands/publish.command');

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,16 +2,32 @@
 require('dotenv').config();
 
 const sade = require('sade');
+const { ExitPromptError } = require('@inquirer/prompts');
 
 const prog = sade('testbeats');
 const { PublishCommand } = require('./commands/publish.command');
+const { GenerateConfigCommand } = require('./commands/generate-config.command');
 const logger = require('./utils/logger');
 const pkg = require('../package.json');
 
+const banner = `
+ _____             _    ___                  _         
+(_   _)           ( )_ (  _'\\               ( )_       
+  | |   __    ___ | ,_)| (_) )   __     _ _ | ,_)  ___ 
+  | | /'__'\\/',__)| |  |  _ <' /'__'\\ /'_' )| |  /',__)
+  | |(  ___/\\__, \\| |_ | (_) )(  ___/( (_| || |_ \\__, \\
+  (_)'\\____)(____/'\\__)(____/''\\____)'\\__,_)'\\__)(____/
+  
+                     v${pkg.version}  
+                Config Generation [BETA]
+`
+
 prog
   .version(pkg.version)
-  .option('-c, --config', 'path to config file')
   .option('-l, --logLevel', 'Log Level', "INFO")
+
+prog.command('publish')
+  .option('-c, --config', 'path to config file')
   .option('--api-key', 'api key')
   .option('--project', 'project name')
   .option('--run', 'run name')
@@ -27,9 +43,7 @@ prog
   .option('--xunit', 'xunit xml path')
   .option('--mstest', 'mstest xml path')
   .option('-ci-info', 'ci info extension')
-  .option('-chart-test-summary', 'chart test summary extension');
-
-prog.command('publish')
+  .option('-chart-test-summary', 'chart test summary extension')
   .action(async (opts) => {
     try {
       logger.setLevel(opts.logLevel);
@@ -37,6 +51,27 @@ prog.command('publish')
       await publish_command.publish();
     } catch (error) {
       logger.error(`Report publish failed: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+prog.command('init')
+  .describe('Generate a TestBeats configuration file')
+  .example('init')
+  .action(async (opts) => {
+    console.log(banner)
+    try {
+      logger.setLevel(opts.logLevel);
+      logger.info(`🚧 Config generation is still in BETA mode, please report any issues at ${pkg.bugs.url}\n`);
+      const generate_command = new GenerateConfigCommand();
+      await generate_command.execute();
+    } catch (error) {
+      if (error.name === 'ExitPromptError') {
+        logger.info('😿 Configuration generation was canceled by the user.');
+      } else {
+        logger.debug(error.stack)
+        throw new Error(`❌ Error in generating configuration file: ${error.message}`)
+      }
       process.exit(1);
     }
   });

--- a/src/commands/generate-config.command.js
+++ b/src/commands/generate-config.command.js
@@ -8,17 +8,16 @@ class GenerateConfigCommand {
     /**
      * TODO: [BETA / Experimental Mode]
      * Generates initial TestBests configuration file
-     *  
      */
     constructor(opts) {
-        this.opts = opts
-        this.answers = {};
+        this.opts = opts;
+        this.configPath = '.testbeats.json';
         this.config = {};
     }
 
     async execute() {
         logger.setLevel(this.opts.logLevel);
-        this.#printBanner()
+        this.#printBanner();
         logger.info(`🚧 Config generation is still in BETA mode, please report any issues at ${pkg.bugs.url}\n`);
 
         await this.#buildConfigFilePath();
@@ -40,7 +39,7 @@ class GenerateConfigCommand {
         
                              v${pkg.version}  
                         Config Generation [BETA]
-        `
+        `;
         console.log(banner);
     }
 
@@ -51,7 +50,7 @@ class GenerateConfigCommand {
             message: 'Enter path for configuration file :',
             initial: '.testbeats.json'
         });
-        this.answers['configPath'] = configPath;
+        this.configPath = configPath;
     }
 
     async #buildTestResultsConfig() {
@@ -83,7 +82,6 @@ class GenerateConfigCommand {
             choices: runnerChoices,
             min: 1
         });
-        this.answers['testResults'] = testResults;
 
         // Handle result paths
         this.config.results = []
@@ -97,7 +95,7 @@ class GenerateConfigCommand {
             this.config.results.push({
                 files: path,
                 type: resultType
-            })
+            });
         }
     }
 
@@ -106,7 +104,7 @@ class GenerateConfigCommand {
             { title: 'Slack', value: 'slack' },
             { title: 'Microsoft Teams', value: 'teams' },
             { title: 'Google Chat', value: 'chat' }
-        ]
+        ];
 
         const { includeTargets } = await prompts({
             type: 'toggle',
@@ -160,7 +158,7 @@ class GenerateConfigCommand {
                     url: `{${webhookEnvVar}}`,
                     publish: 'test-summary'
                 }
-            }
+            };
 
             if (useExtensions) {
                 targetConfig.extensions = [];
@@ -400,11 +398,7 @@ class GenerateConfigCommand {
                 message: 'Enter project name (optional):'
             });
 
-            // testBeatsConfig.push({
-            //     api_key: apiKey,
-            //     project
-            // });
-            this.config.api_key = this.answers.apiKey;
+            this.config.api_key = apiKey;
             // Add optional fields only if they have values
             if (project?.trim()) {
                 this.config.project = project.trim();
@@ -424,8 +418,8 @@ class GenerateConfigCommand {
     async #saveConfigFile() {
         // Write config to file
         try {
-            await fs.writeFile(this.answers.configPath, JSON.stringify(this.config, null, 2));
-            logger.info(`✅ Configuration file successfully generated: ${this.answers.configPath}`);
+            await fs.writeFile(this.configPath, JSON.stringify(this.config, null, 2));
+            logger.info(`✅ Configuration file successfully generated: ${this.configPath}`);
         } catch (error) {
             throw new Error(`Error: ${error.message}`)
         }

--- a/src/commands/generate-config.command.js
+++ b/src/commands/generate-config.command.js
@@ -1,6 +1,7 @@
 const prompts = require('prompts');
 const fs = require('fs/promises');
 const logger = require('../utils/logger');
+const pkg = require('../../package.json');
 
 
 class GenerateConfigCommand {
@@ -9,81 +10,103 @@ class GenerateConfigCommand {
      * Generates initial TestBests configuration file
      *  
      */
-    constructor() {
-        this.answers = [];
-        this.config = []
+    constructor(opts) {
+        this.opts = opts
+        this.answers = {};
+        this.config = {};
     }
 
     async execute() {
-        this.answers = await this.#promptQuestions();
-        this.config = this.#generateConfigObject(this.answers);
-        
-        // Write config to file
-        try {
-            await fs.writeFile(this.answers.configPath, JSON.stringify(this.config, null, 2));
-            logger.info(`✅ Configuration file successfully generated: ${this.answers.configPath}`);
-        } catch (error) {
-            throw new Error(`Error: ${error.message}`)
-        }
-    }
-    
-    async #promptQuestions() {
-        // Prompt user input questions for the configuration
-        let targets = [];
-        let webhookEnvVars = [];
-        let title = '';
-        let testResults = [];
-        const testBeatsConfig = {};
-        const targetExtensions = {};
-        const globalExtensions = [];
-        const extensionsList = [
-            { title: 'Quick Chart Test Summary', value: 'quick-chart-test-summary' },
-            { title: 'CI Information', value: 'ci-info' },
-            { title: 'Hyperlinks', value: 'hyperlinks' },
-            { title: 'Mentions', value: 'mentions' },
-            { title: 'Report Portal Analysis', value: 'report-portal-analysis' },
-            { title: 'Report Portal History', value: 'report-portal-history' },
-            { title: 'Percy Analysis', value: 'percy-analysis' },
-            { title: 'Metadata', value: 'metadata' },
-            { title: 'AI Failure Summary', value: 'ai-failure-summary' },
-            { title: 'Smart Analysis', value: 'smart-analysis' },
-            { title: 'Error Clusters', value: 'error-clusters' }
-        ];
+        logger.setLevel(this.opts.logLevel);
+        this.#printBanner()
+        logger.info(`🚧 Config generation is still in BETA mode, please report any issues at ${pkg.bugs.url}\n`);
 
-        // Get initial answers
-        const { configPath, includeResults } = await prompts([{
+        await this.#buildConfigFilePath();
+        await this.#buildTestResultsConfig();
+        await this.#buildTargetsConfig();
+        await this.#buildGobalExtensionConfig();
+        await this.#buildTestBeatsPortalConfig();
+        await this.#saveConfigFile();
+    }
+
+    #printBanner() {
+        const banner = `
+         _____             _    ___                  _         
+        (_   _)           ( )_ (  _'\\               ( )_       
+          | |   __    ___ | ,_)| (_) )   __     _ _ | ,_)  ___ 
+          | | /'__'\\/',__)| |  |  _ <' /'__'\\ /'_' )| |  /',__)
+          | |(  ___/\\__, \\| |_ | (_) )(  ___/( (_| || |_ \\__, \\
+          (_)'\\____)(____/'\\__)(____/''\\____)'\\__,_)'\\__)(____/
+        
+                             v${pkg.version}  
+                        Config Generation [BETA]
+        `
+        console.log(banner);
+    }
+
+    async #buildConfigFilePath() {
+        const { configPath } = await prompts({
             type: 'text',
             name: 'configPath',
             message: 'Enter path for configuration file :',
             initial: '.testbeats.json'
-        },
-        {
+        });
+        this.answers['configPath'] = configPath;
+    }
+
+    async #buildTestResultsConfig() {
+        const runnerChoices = [
+            { title: 'Mocha', value: 'mocha', selected: true },
+            { title: 'JUnit', value: 'junit' },
+            { title: 'TestNG', value: 'testng' },
+            { title: 'Cucumber', value: 'cucumber' },
+            { title: 'NUnit', value: 'nunit' },
+            { title: 'xUnit', value: 'xunit' },
+            { title: 'MSTest', value: 'mstest' }
+        ]
+        // Get test results details
+        const { includeResults } = await prompts({
             type: 'toggle',
             name: 'includeResults',
             message: 'Do you want to configure test results?',
             initial: true,
             active: 'Yes',
             inactive: 'No'
-        }]);
+        });
 
-        if (includeResults) {
-            const response = await prompts({
-                type: 'multiselect',
-                name: 'testResults',
-                message: 'Select test result types to include:',
-                choices: [
-                    { title: 'Mocha', value: 'mocha', selected: true },
-                    { title: 'JUnit', value: 'junit' },
-                    { title: 'TestNG', value: 'testng' },
-                    { title: 'Cucumber', value: 'cucumber' },
-                    { title: 'NUnit', value: 'nunit' },
-                    { title: 'xUnit', value: 'xunit' },
-                    { title: 'MSTest', value: 'mstest' }
-                ],
-                min: 1
+        if (!includeResults) { return };
+
+        const { testResults } = await prompts({
+            type: 'multiselect',
+            name: 'testResults',
+            message: 'Select test result types to include:',
+            choices: runnerChoices,
+            min: 1
+        });
+        this.answers['testResults'] = testResults;
+
+        // Handle result paths
+        this.config.results = []
+        for (const resultType of testResults) {
+            const { path } = await prompts({
+                type: 'text',
+                name: 'path',
+                message: `Enter file path for ${resultType} results (.json, .xml etc):`,
+                initial: ""
             });
-            testResults = response.testResults;
+            this.config.results.push({
+                files: path,
+                type: resultType
+            })
         }
+    }
+
+    async #buildTargetsConfig() {
+        const targetChoices = [
+            { title: 'Slack', value: 'slack' },
+            { title: 'Microsoft Teams', value: 'teams' },
+            { title: 'Google Chat', value: 'chat' }
+        ]
 
         const { includeTargets } = await prompts({
             type: 'toggle',
@@ -94,67 +117,72 @@ class GenerateConfigCommand {
             inactive: 'No'
         });
 
-        if (includeTargets) {
-            const response = await prompts({
-                type: 'multiselect',
-                name: 'targets',
-                message: 'Select notification targets:',
-                choices: [
-                    { title: 'Slack', value: 'slack' },
-                    { title: 'Microsoft Teams', value: 'teams' },
-                    { title: 'Google Chat', value: 'chat' }
-                ],
-                min: 1
+        if (!includeTargets) { return }
+
+        this.config.targets = []
+        const { targets } = await prompts({
+            type: 'multiselect',
+            name: 'targets',
+            message: 'Select notification targets:',
+            choices: targetChoices,
+            min: 1
+        });
+
+        const { titleInput } = await prompts({
+            type: 'text',
+            name: 'titleInput',
+            message: 'Enter notification title (optional):',
+            initial: 'TestBeats Report'
+        });
+
+        // For each target, ask about target-specific extensions
+        for (const target of targets) {
+            const { webhookEnvVar } = await prompts({
+                type: 'text',
+                name: 'webhookEnvVar',
+                message: `Enter environment variable name for ${target} webhook URL:`,
+                initial: `${target.toUpperCase()}_WEBHOOK_URL`
             });
-            targets = response.targets;
 
-            if (targets.length > 0) {
-                const { titleInput } = await prompts({
-                    type: 'text',
-                    name: 'titleInput',
-                    message: 'Enter notification title (optional):'
-                });
-                title = titleInput;
+            const { useExtensions } = await prompts({
+                type: 'toggle',
+                name: 'useExtensions',
+                message: `Do you want to configure extensions for ${target}?`,
+                initial: true,
+                active: 'Yes',
+                inactive: 'No'
+            });
 
-                // For each target, ask about target-specific extensions
-                for (const target of targets) {
-                    const { webhookEnvVar } = await prompts({
-                        type: 'text',
-                        name: 'webhookEnvVar',
-                        message: `Enter environment variable name for ${target} webhook URL:`,
-                        initial: `${target.toUpperCase()}_WEBHOOK_URL`
-                    });
-                    webhookEnvVars[target] = webhookEnvVar;
-
-                    const { useExtensions } = await prompts({
-                        type: 'toggle',
-                        name: 'useExtensions',
-                        message: `Do you want to configure extensions for ${target}?`,
-                        initial: true,
-                        active: 'Yes',
-                        inactive: 'No'
-                    });
-
-                    if (useExtensions) {
-                        targetExtensions[`${target}Extensions`] = true;
-                        const { selectedExtensions } = await prompts({
-                            type: 'multiselect',
-                            name: 'selectedExtensions',
-                            message: `Select extensions for ${target}:`,
-                            choices: extensionsList,
-                            min: 1
-                        });
-                        targetExtensions[`${target}ExtensionsList`] = selectedExtensions;
-
-                        // Configure extension-specific inputs
-                        for (const ext of targetExtensions[`${target}ExtensionsList`]) {
-                            targetExtensions[`${target}${ext}Config`] = await this.#promptExtensionConfig(ext, target);
-                        }
-                    }
+            const targetConfig = {
+                name: target,
+                inputs: {
+                    title: titleInput,
+                    url: `{${webhookEnvVar}}`,
+                    publish: 'test-summary'
                 }
             }
-        }
 
+            if (useExtensions) {
+                targetConfig.extensions = [];
+                const { selectedExtensions } = await prompts({
+                    type: 'multiselect',
+                    name: 'selectedExtensions',
+                    message: `Select extensions for ${target}:`,
+                    choices: this.#getExtensionsList(),
+                    min: 1
+                });
+
+                // Configure extension-specific inputs
+                for (const ext of selectedExtensions) {
+                    const extConfig = await this.#buildExtensionConfig(ext, target);
+                    targetConfig.extensions.push(extConfig);
+                }
+            }
+            this.config.targets.push(targetConfig);
+        }
+    }
+
+    async #buildGobalExtensionConfig() {
         const { includeGlobalExtensions } = await prompts({
             type: 'toggle',
             name: 'includeGlobalExtensions',
@@ -164,35 +192,190 @@ class GenerateConfigCommand {
             inactive: 'No'
         });
 
-        if (includeGlobalExtensions) {
-            const { globalExtensionsSelected } = await prompts({
-                type: 'multiselect',
-                name: 'globalExtensionsSelected',
-                message: 'Select global extensions to enable:',
-                choices: extensionsList
-            });
+        if (!includeGlobalExtensions) { return };
 
-            // Configure extension-specific inputs
-            for (const ext of globalExtensionsSelected) {
-                const extDetails = await this.#promptExtensionConfig(ext, null);
-                globalExtensions.push(extDetails);
-            }
+        this.config.extensions = [];
+        const { globalExtensionsSelected } = await prompts({
+            type: 'multiselect',
+            name: 'globalExtensionsSelected',
+            message: 'Select global extensions to enable:',
+            choices: this.#getExtensionsList()
+        });
+
+        // Configure extension-specific inputs
+        for (const ext of globalExtensionsSelected) {
+            const extDetails = await this.#buildExtensionConfig(ext, null);
+            this.config.extensions.push(extDetails);
         }
+    }
 
-        // Handle result paths
-        const resultPaths = {};
-        if (testResults.length > 0) {
-            for (const resultType of testResults) {
-                const { path } = await prompts({
+    async #buildExtHyperlinks() {
+        const links = [];
+        const { addLink } = await prompts({
+            type: 'toggle',
+            name: 'addLink',
+            message: 'Do you want to add a hyperlink?',
+            initial: true,
+            active: 'Yes',
+            inactive: 'No'
+        });
+
+        while (addLink) {
+            const { text, url } = await prompts([
+                {
                     type: 'text',
-                    name: 'path',
-                    message: `Enter file path for ${resultType} results (.json, .xml etc):`,
-                    initial: ""
-                });
-                resultPaths[`${resultType}Path`] = path;
-            }
-        }
+                    name: 'text',
+                    message: 'Enter link text:'
+                },
+                {
+                    type: 'text',
+                    name: 'url',
+                    message: 'Enter link URL:'
+                }
+            ]);
 
+            links.push({ text, url });
+
+            const { addAnother } = await prompts({
+                type: 'toggle',
+                name: 'addAnother',
+                message: 'Add another link?',
+                initial: false,
+                active: 'Yes',
+                inactive: 'No'
+            });
+            if (!addAnother) break;
+        }
+        return { links };
+    }
+
+    async #buildExtMentions(targetName) {
+        const users = [];
+        const { addUser } = await prompts({
+            type: 'toggle',
+            name: 'addUser',
+            message: 'Do you want to add user mentions?',
+            initial: true,
+            active: 'Yes',
+            inactive: 'No'
+        });
+
+        while (addUser) {
+            const user = {};
+            const { name } = await prompts({
+                type: 'text',
+                name: 'name',
+                message: 'Enter user name:'
+            });
+            user.name = name;
+
+            if (targetName === 'teams') {
+                const { teams_upn } = await prompts({
+                    type: 'text',
+                    name: 'teams_upn',
+                    message: 'Enter Teams UPN (user principal name):'
+                });
+                user.teams_upn = teams_upn;
+            } else if (targetName === 'slack') {
+                const { slack_uid } = await prompts({
+                    type: 'text',
+                    name: 'slack_uid',
+                    message: 'Enter Slack user ID:'
+                });
+                user.slack_uid = slack_uid;
+            } else if (targetName === 'chat') {
+                const { chat_uid } = await prompts({
+                    type: 'text',
+                    name: 'chat_uid',
+                    message: 'Enter Google Chat user ID:'
+                });
+                user.chat_uid = chat_uid;
+            }
+
+            users.push(user);
+
+            const { addAnother } = await prompts({
+                type: 'toggle',
+                name: 'addAnother',
+                message: 'Add another user?',
+                initial: false,
+                active: 'Yes',
+                inactive: 'No'
+            });
+            if (!addAnother) break;
+        }
+        return { users };
+    }
+
+    async #buildExtMetadata() {
+        const data = [];
+        const { addMetadata } = await prompts({
+            type: 'toggle',
+            name: 'addMetadata',
+            message: 'Do you want to add metadata?',
+            initial: true,
+            active: 'Yes',
+            inactive: 'No'
+        });
+
+        while (addMetadata) {
+            const { key, value } = await prompts([
+                {
+                    type: 'text',
+                    name: 'key',
+                    message: 'Enter metadata key:'
+                },
+                {
+                    type: 'text',
+                    name: 'value',
+                    message: 'Enter metadata value:'
+                }
+            ]);
+
+            data.push({ key, value });
+
+            const { addAnother } = await prompts({
+                type: 'toggle',
+                name: 'addAnother',
+                message: 'Add another metadata item?',
+                initial: false,
+                active: 'Yes',
+                inactive: 'No'
+            });
+            if (!addAnother) break;
+        }
+        return { data };
+    }
+
+    async #buildExtensionConfig(extension, target) {
+        const extConfig = {
+            name: extension
+        };
+
+        switch (extension) {
+            case 'hyperlinks':
+                extConfig.inputs = await this.#buildExtHyperlinks()
+                break;
+
+            case 'mentions':
+                extConfig.inputs = await this.#buildExtMentions(target);
+                break;
+
+            case 'metadata':
+                extConfig.inputs = await this.#buildExtMetadata();
+                break;
+
+            default:
+                // Add default configuration for other extensions
+                extConfig.inputs = {
+                    title: '',
+                    separator: target === 'slack' ? false : true
+                };
+        }
+        return extConfig;
+    }
+
+    async #buildTestBeatsPortalConfig() {
         // TestBeats configuration
         const { includeTestBeats } = await prompts({
             type: 'toggle',
@@ -217,258 +400,53 @@ class GenerateConfigCommand {
                 message: 'Enter project name (optional):'
             });
 
-            testBeatsConfig.push({
-                api_key: apiKey,
-                project
-            });
-        }
-
-        // Combine all answers
-        return {
-            configPath,
-            ...testBeatsConfig,
-            includeResults,
-            testResults,
-            includeTargets,
-            targets,
-            webhookEnvVars,
-            title,
-            includeGlobalExtensions,
-            globalExtensions,
-            ...targetExtensions,
-            ...resultPaths
-        };
-    }
-  
-    async #promptExtensionConfig(extension, target) {
-        const config = {
-            name: extension
-        };
-
-        switch (extension) {
-            case 'hyperlinks':
-                const links = [];
-                const { addLink } = await prompts({
-                    type: 'toggle',
-                    name: 'addLink',
-                    message: 'Do you want to add a hyperlink?',
-                    initial: true,
-                    active: 'Yes',
-                    inactive: 'No'
-                });
-                
-                while (addLink) {
-                    const { text, url, condition } = await prompts([
-                        {
-                            type: 'text',
-                            name: 'text',
-                            message: 'Enter link text:'
-                        },
-                        {
-                            type: 'text',
-                            name: 'url',
-                            message: 'Enter link URL:'
-                        },
-                        {
-                            type: 'text',
-                            name: 'condition',
-                            message: 'Enter condition (PASS, FAIL, or PASS_OR_FAIL):',
-                            initial: 'PASS_OR_FAIL'
-                        }
-                    ]);
-
-                    links.push({ text, url, condition });
-
-                    const { addAnother } = await prompts({
-                        type: 'toggle',
-                        name: 'addAnother',
-                        message: 'Add another link?',
-                        initial: false,
-                        active: 'Yes',
-                        inactive: 'No'
-                    });
-                    if (!addAnother) break;
-                }
-                config.inputs = { links };
-                break;
-
-            case 'mentions':
-                const users = [];
-                const { addUser } = await prompts({
-                    type: 'toggle',
-                    name: 'addUser',
-                    message: 'Do you want to add user mentions?',
-                    initial: true,
-                    active: 'Yes',
-                    inactive: 'No'
-                });
-
-                while (addUser) {
-                    const user = {};
-                    const { name } = await prompts({
-                        type: 'text',
-                        name: 'name',
-                        message: 'Enter user name:'
-                    });
-                    user.name = name;
-                    
-                    if (target === 'teams') {
-                        const { teams_upn } = await prompts({
-                            type: 'text',
-                            name: 'teams_upn',
-                            message: 'Enter Teams UPN (user principal name):'
-                        });
-                        user.teams_upn = teams_upn;
-                    } else if (target === 'slack') {
-                        const { slack_uid } = await prompts({
-                            type: 'text',
-                            name: 'slack_uid',
-                            message: 'Enter Slack user ID:'
-                        });
-                        user.slack_uid = slack_uid;
-                    } else if (target === 'chat') {
-                        const { chat_uid } = await prompts({
-                            type: 'text',
-                            name: 'chat_uid',
-                            message: 'Enter Google Chat user ID:'
-                        });
-                        user.chat_uid = chat_uid;
-                    }
-
-                    users.push(user);
-
-                    const { addAnother } = await prompts({
-                        type: 'toggle',
-                        name: 'addAnother',
-                        message: 'Add another user?',
-                        initial: false,
-                        active: 'Yes',
-                        inactive: 'No'
-                    });
-                    if (!addAnother) break;
-                }
-                config.inputs = { users };
-                break;
-
-            case 'metadata':
-                const data = [];
-                const { addMetadata } = await prompts({
-                    type: 'toggle',
-                    name: 'addMetadata',
-                    message: 'Do you want to add metadata?',
-                    initial: true,
-                    active: 'Yes',
-                    inactive: 'No'
-                });
-
-                while (addMetadata) {
-                    const { key, value, condition } = await prompts([
-                        {
-                            type: 'text',
-                            name: 'key',
-                            message: 'Enter metadata key:'
-                        },
-                        {
-                            type: 'text',
-                            name: 'value',
-                            message: 'Enter metadata value:'
-                        },
-                        {
-                            type: 'text',
-                            name: 'condition',
-                            message: 'Enter condition (PASS, FAIL, or PASS_OR_FAIL):',
-                            initial: 'PASS_OR_FAIL'
-                        }
-                    ]);
-
-                    data.push({ key, value, condition });
-
-                    const { addAnother } = await prompts({
-                        type: 'toggle',
-                        name: 'addAnother',
-                        message: 'Add another metadata item?',
-                        initial: false,
-                        active: 'Yes',
-                        inactive: 'No'
-                    });
-                    if (!addAnother) break;
-                }
-                config.inputs = { data };
-                break;
-
-            // Add default configuration for other extensions
-            default:
-                config.inputs = {
-                    title: '',
-                    separator: target === 'slack' ? false : true
-                };
-        }
-
-        return config;
-    }
-  
-    #generateConfigObject() {
-      const config = {};
-  
-      // Add API key (required)
-      config.api_key = this.answers.apiKey;
-  
-      // Add optional fields only if they have values
-      if (this.answers.project?.trim()) {
-        config.project = this.answers.project.trim();
-      }
-  
-      // Add test results if included
-      if (this.answers.includeResults && Array.isArray(this.answers.testResults) && this.answers.testResults.length > 0) {
-        // Check if result paths exist before mapping
-        const validResults = this.answers.testResults.filter(type => this.answers[`${type}Path`]);
-        if (validResults.length > 0) {
-            config.results = validResults.map(type => ({
-                files: [this.answers[`${type}Path`]],
-                type
-            }));
-        }
-      }
-  
-      // Add global extensions if included
-      if (this.answers.includeGlobalExtensions && this.answers.globalExtensions?.length > 0) {
-        config.extensions = this.answers.globalExtensions.map(name => ({ name }));
-      }
-  
-      // Add targets if included
-      if (this.answers.includeTargets && this.answers.targets?.length > 0) {
-        config.targets = this.answers.targets.map(target => {
-          const targetConfig = {
-            name: target,
-            inputs: {
-              url: `{${this.answers.webhookEnvVars[target]}}`,
-              publish: 'test-summary'
+            // testBeatsConfig.push({
+            //     api_key: apiKey,
+            //     project
+            // });
+            this.config.api_key = this.answers.apiKey;
+            // Add optional fields only if they have values
+            if (project?.trim()) {
+                this.config.project = project.trim();
             }
-          };
-  
-          if (this.answers.title?.trim()) {
-            targetConfig.inputs.title = this.answers.title.trim();
-          }
-  
-          // Add target-specific extensions with their configurations
-          if (this.answers[`${target}Extensions`] && this.answers[`${target}ExtensionsList`]?.length > 0) {
-            targetConfig.extensions = this.answers[`${target}ExtensionsList`].map(ext => {
-                return this.answers[`${target}${ext}Config`];
-            });
-          }
-  
-          return targetConfig;
-        });
-      }
-  
-      // Sort keys alphabetically
-      return Object.keys(config).sort()
-                .reduce((sortedConfig, key) => {
-                    sortedConfig[key] = config[key];
-                    return sortedConfig;
-                }, {});
+        }
     }
-  
+
+    #sortConfig() {
+        // Sort keys alphabetically
+        this.config = Object.keys(this.config).sort()
+            .reduce((sortedConfig, key) => {
+                sortedConfig[key] = this.config[key];
+                return sortedConfig;
+            }, {});
+    }
+
+    async #saveConfigFile() {
+        // Write config to file
+        try {
+            await fs.writeFile(this.answers.configPath, JSON.stringify(this.config, null, 2));
+            logger.info(`✅ Configuration file successfully generated: ${this.answers.configPath}`);
+        } catch (error) {
+            throw new Error(`Error: ${error.message}`)
+        }
+    }
+
+    #getExtensionsList() {
+        // List of Extensions supported
+        return [
+            { title: 'Quick Chart Test Summary', value: 'quick-chart-test-summary' },
+            { title: 'CI Information', value: 'ci-info' },
+            { title: 'Hyperlinks', value: 'hyperlinks' },
+            { title: 'Mentions', value: 'mentions' },
+            { title: 'Report Portal Analysis', value: 'report-portal-analysis' },
+            { title: 'Report Portal History', value: 'report-portal-history' },
+            { title: 'Percy Analysis', value: 'percy-analysis' },
+            { title: 'Metadata', value: 'metadata' },
+            { title: 'AI Failure Summary', value: 'ai-failure-summary' },
+            { title: 'Smart Analysis', value: 'smart-analysis' },
+            { title: 'Error Clusters', value: 'error-clusters' }
+        ];
+    }
 }
 
 module.exports = { GenerateConfigCommand }; 

--- a/src/commands/generate-config.command.js
+++ b/src/commands/generate-config.command.js
@@ -1,0 +1,361 @@
+const { input, confirm, checkbox } = require('@inquirer/prompts');
+const fs = require('fs/promises');
+const logger = require('../utils/logger');
+
+
+class GenerateConfigCommand {
+    /**
+     * TODO: [BETA / Experimental Mode]
+     * Generates initial TestBests configuration file
+     *  
+     */
+    constructor() {
+        this.answers = [];
+        this.config = []
+    }
+
+    async execute() {
+        this.answers = await this.#promptQuestions();
+        this.config = this.#generateConfigObject(this.answers);
+        
+        // Write config to file
+        try {
+            await fs.writeFile(this.answers.configPath, JSON.stringify(this.config, null, 2));
+            logger.info(`✅ Configuration file successfully generated: ${this.answers.configPath}`);
+        } catch (error) {
+            throw new Error(`Error: ${error.message}`)
+        }
+    }
+    
+    async #promptQuestions() {
+        // Prompt user input questions for the configuration
+        let targets = [];
+        let webhookEnvVars = [];
+        let title = '';
+        let testResults = [];
+        const testBeatsConfig = {};
+        const targetExtensions = {};
+        const globalExtensions = [];
+        const extensionsList = [
+            { name: 'Quick Chart Test Summary', value: 'quick-chart-test-summary' },
+            { name: 'CI Information', value: 'ci-info' },
+            { name: 'Hyperlinks', value: 'hyperlinks' },
+            { name: 'Mentions', value: 'mentions' },
+            { name: 'Report Portal Analysis', value: 'report-portal-analysis' },
+            { name: 'Report Portal History', value: 'report-portal-history' },
+            { name: 'Percy Analysis', value: 'percy-analysis' },
+            { name: 'Metadata', value: 'metadata' },
+            { name: 'AI Failure Summary', value: 'ai-failure-summary' },
+            { name: 'Smart Analysis', value: 'smart-analysis' },
+            { name: 'Error Clusters', value: 'error-clusters' }
+        ];
+
+        // Get initial answers
+        const configPath = await input({
+            message: 'Enter path for configuration file :',
+            default: '.testbeats.json'
+        });
+
+        const includeResults = await confirm({
+            message: 'Do you want to configure test results?',
+            default: true
+        });
+
+        if (includeResults) {
+            testResults = await checkbox({
+                message: 'Select test result types to include:',
+                choices: [
+                    { name: 'Mocha', value: 'mocha' , checked: true},
+                    { name: 'JUnit', value: 'junit' },
+                    { name: 'TestNG', value: 'testng' },
+                    { name: 'Cucumber', value: 'cucumber' },
+                    { name: 'NUnit', value: 'nunit' },
+                    { name: 'xUnit', value: 'xunit' },
+                    { name: 'MSTest', value: 'mstest' }
+                ],
+                required: true
+            });
+        }
+
+        const includeTargets = await confirm({
+            message: 'Do you want to configure notification targets (slack, teams, chat etc)?',
+            default: true
+        });
+
+        if (includeTargets) {
+            targets = await checkbox({
+                message: 'Select notification targets:',
+                choices: [
+                    { name: 'Slack', value: 'slack' },
+                    { name: 'Microsoft Teams', value: 'teams' },
+                    { name: 'Google Chat', value: 'chat' }
+                ],
+                required: true
+            });
+
+            if (targets.length > 0) {
+
+                title = await input({
+                    message: 'Enter notification title (optional):'
+                });
+
+                // For each target, ask about target-specific extensions
+                for (const target of targets) {
+                    webhookEnvVars[target] = await input({
+                        message: `Enter environment variable name for ${target} webhook URL:`,
+                        default: `${target.toUpperCase()}_WEBHOOK_URL`
+                    });
+
+                    const useExtensions = await confirm({
+                        message: `Do you want to configure extensions for ${target}?`,
+                        default: true
+                    });
+
+                    if (useExtensions) {
+                        targetExtensions[`${target}Extensions`] = true;
+                        targetExtensions[`${target}ExtensionsList`] = await checkbox({
+                            message: `Select extensions for ${target}:`,
+                            choices: extensionsList,
+                            required: true
+                        });
+
+                        // Configure extension-specific inputs
+                        for (const ext of targetExtensions[`${target}ExtensionsList`]) {
+                            targetExtensions[`${target}${ext}Config`] = await this.#promptExtensionConfig(ext, target);
+                        }
+                    }
+                }
+            }
+        }
+
+        const includeGlobalExtensions = await confirm({
+            message: 'Do you want to configure global extensions?',
+            default: false
+        });
+
+        if (includeGlobalExtensions) {
+            const globalExtensionsSelected = await checkbox({
+                message: 'Select global extensions to enable:',
+                choices: extensionsList
+            });
+            // Configure extension-specific inputs
+            for (const ext of globalExtensionsSelected) {
+                const extDetails = await this.#promptExtensionConfig(ext, null);
+                globalExtensions.push(extDetails);
+            }
+        }
+
+        // Handle result paths
+        const resultPaths = {};
+        if (testResults.length > 0) {
+            for (const resultType of testResults) {
+                resultPaths[`${resultType}Path`] = await input({
+                    message: `Enter file path for ${resultType} results (.json, .xml etc):`,
+                    default: "",
+                });
+            }
+        }
+
+        // TestBeats configuration
+        const includeTestBeats = await confirm({
+            message: 'Do you want to configure TestBeats API key (optional)?',
+            default: false
+        });
+
+        if (includeTestBeats) {
+            const apiKey = await input({
+                message: 'Enter environment variable name for API key (optional):',
+                default: '{TEST_RESULTS_API_KEY}'
+            });
+
+            const project = await input({
+                message: 'Enter project name (optional):'
+            });
+
+            testBeatsConfig.push({
+                api_key: apiKey,
+                project
+            });
+        }
+
+        // Combine all answers
+        return {
+            configPath,
+            ...testBeatsConfig,
+            includeResults,
+            testResults,
+            includeTargets,
+            targets,
+            webhookEnvVars,
+            title,
+            includeGlobalExtensions,
+            globalExtensions,
+            ...targetExtensions,
+            ...resultPaths
+        };
+    }
+  
+    async #promptExtensionConfig(extension, target) {
+        const config = {
+            name: extension
+        };
+
+        switch (extension) {
+            case 'hyperlinks':
+                const links = [];
+                const addLink = await confirm({
+                    message: 'Do you want to add a hyperlink?',
+                    default: true
+                });
+                
+                while (addLink) {
+                    links.push({
+                        text: await input({ message: 'Enter link text:' }),
+                        url: await input({ message: 'Enter link URL:' }),
+                        condition: await input({
+                            message: 'Enter condition (PASS, FAIL, or PASS_OR_FAIL):',
+                            default: 'PASS_OR_FAIL'
+                        })
+                    });
+
+                    const addAnother = await confirm({
+                        message: 'Add another link?',
+                        default: false
+                    });
+                    if (!addAnother) break;
+                }
+                config.inputs = { links };
+                break;
+
+            case 'mentions':
+                const users = [];
+                const addUser = await confirm({
+                    message: 'Do you want to add user mentions?',
+                    default: true
+                });
+
+                while (addUser) {
+                    const user = {};
+                    user.name = await input({ message: 'Enter user name:' });
+                    
+                    if (target === 'teams') {
+                        user.teams_upn = await input({ message: 'Enter Teams UPN (user principal name):' });
+                    } else if (target === 'slack') {
+                        user.slack_uid = await input({ message: 'Enter Slack user ID:' });
+                    } else if (target === 'chat') {
+                        user.chat_uid = await input({ message: 'Enter Google Chat user ID:' });
+                    }
+
+                    users.push(user);
+
+                    const addAnother = await confirm({
+                        message: 'Add another user?',
+                        default: false
+                    });
+                    if (!addAnother) break;
+                }
+                config.inputs = { users };
+                break;
+
+            case 'metadata':
+                const data = [];
+                const addMetadata = await confirm({
+                    message: 'Do you want to add metadata?',
+                    default: true
+                });
+
+                while (addMetadata) {
+                    data.push({
+                        key: await input({ message: 'Enter metadata key:' }),
+                        value: await input({ message: 'Enter metadata value:' }),
+                        condition: await input({
+                            message: 'Enter condition (PASS, FAIL, or PASS_OR_FAIL):',
+                            default: 'PASS_OR_FAIL'
+                        })
+                    });
+
+                    const addAnother = await confirm({
+                        message: 'Add another metadata item?',
+                        default: false
+                    });
+                    if (!addAnother) break;
+                }
+                config.inputs = { data };
+                break;
+
+            // Add default configuration for other extensions
+            default:
+                config.inputs = {
+                    title: '',
+                    separator: target === 'slack' ? false : true
+                };
+        }
+
+        return config;
+    }
+  
+    #generateConfigObject() {
+      const config = {};
+  
+      // Add API key (required)
+      config.api_key = this.answers.apiKey;
+  
+      // Add optional fields only if they have values
+      if (this.answers.project?.trim()) {
+        config.project = this.answers.project.trim();
+      }
+  
+      // Add test results if included
+      if (this.answers.includeResults && Array.isArray(this.answers.testResults) && this.answers.testResults.length > 0) {
+        // Check if result paths exist before mapping
+        const validResults = this.answers.testResults.filter(type => this.answers[`${type}Path`]);
+        if (validResults.length > 0) {
+            config.results = validResults.map(type => ({
+                files: [this.answers[`${type}Path`]],
+                type
+            }));
+        }
+      }
+  
+      // Add global extensions if included
+      if (this.answers.includeGlobalExtensions && this.answers.globalExtensions?.length > 0) {
+        config.extensions = this.answers.globalExtensions.map(name => ({ name }));
+      }
+  
+      // Add targets if included
+      if (this.answers.includeTargets && this.answers.targets?.length > 0) {
+        config.targets = this.answers.targets.map(target => {
+          const targetConfig = {
+            name: target,
+            inputs: {
+              url: `{${this.answers.webhookEnvVars[target]}}`,
+              publish: 'test-summary'
+            }
+          };
+  
+          if (this.answers.title?.trim()) {
+            targetConfig.inputs.title = this.answers.title.trim();
+          }
+  
+          // Add target-specific extensions with their configurations
+          if (this.answers[`${target}Extensions`] && this.answers[`${target}ExtensionsList`]?.length > 0) {
+            targetConfig.extensions = this.answers[`${target}ExtensionsList`].map(ext => {
+                return this.answers[`${target}${ext}Config`];
+            });
+          }
+  
+          return targetConfig;
+        });
+      }
+  
+      // Sort keys alphabetically
+      return Object.keys(config).sort()
+                .reduce((sortedConfig, key) => {
+                    sortedConfig[key] = config[key];
+                    return sortedConfig;
+                }, {});
+    }
+  
+}
+
+module.exports = { GenerateConfigCommand }; 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,22 @@
 const { PublishCommand } = require('./commands/publish.command');
+const { GenerateConfigCommand } = require('./commands/generate-config.command');
 
 function publish(options) {
   const publish_command = new PublishCommand(options);
   return publish_command.publish();
 }
 
+function generateConfig() {
+  const generate_command = new GenerateConfigCommand();
+  return generate_command.execute();
+}
+
 function defineConfig(config) {
-  return config
+  return config;
 }
 
 module.exports = {
   publish,
+  generateConfig,
   defineConfig
 }


### PR DESCRIPTION
**Summary**
- Add command to generate testbeats config.
- To be used with `npx testbeats init`
- Generates basic configuration to avoid manual config creation and saves time.
- Avoid typos and miscofigurations
- Feature is in Beta mode

<img width="948" alt="image" src="https://github.com/user-attachments/assets/8f87f130-2adf-4c07-a324-d30796cf45ca">

