### PR TITLE
feat: Extend ci-info extension to get Circle CI information

### DIFF
--- a/src/helpers/ci/circle-ci.js
+++ b/src/helpers/ci/circle-ci.js
@@ -1,0 +1,29 @@
+const ENV = process.env;
+
+/**
+ * @returns {import('../../extensions/extensions').ICIInfo}
+ */
+function info() {
+  const circle = {
+    ci: 'CIRCLE_CI',
+    git: '',
+    repository_url: ENV.CIRCLE_REPOSITORY_URL,
+    repository_name: ENV.CIRCLE_PROJECT_REPONAME, // Need to find a better match
+    repository_ref: ENV.CIRCLE_BRANCH,
+    repository_commit_sha: ENV.CIRCLE_SHA1,
+    branch_url: '',
+    branch_name: ENV.CIRCLE_BRANCH,
+    pull_request_url:'',
+    pull_request_name: '',
+    build_url: ENV.CIRCLE_BUILD_URL,
+    build_number: ENV.CIRCLE_BUILD_NUM,
+    build_name: ENV.CIRCLE_JOB,
+    build_reason: 'Push',
+    user: ENV.CIRCLE_USERNAME,
+  }
+  return circle
+}
+
+module.exports = {
+  info
+}

--- a/src/helpers/ci/index.js
+++ b/src/helpers/ci/index.js
@@ -3,6 +3,7 @@ const github = require('./github');
 const gitlab = require('./gitlab');
 const jenkins = require('./jenkins');
 const azure_devops = require('./azure-devops');
+const circle_ci = require('./circle-ci');
 const system = require('./system');
 
 const ENV = process.env;
@@ -31,6 +32,9 @@ function getBaseCIInfo() {
   }
   if (ENV.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) {
     return azure_devops.info();
+  }
+  if (ENV.CIRCLECI) {
+    return circle_ci.info();
   }
   return getDefaultInformation();
 }

--- a/test/ext-ci-info.spec.js
+++ b/test/ext-ci-info.spec.js
@@ -14,16 +14,26 @@ describe('extensions - ci-info', () => {
     process.env.GITHUB_RUN_NUMBER = '';
     process.env.GITHUB_WORKFLOW = '';
 
-    process.env.GITLAB_CI=''
-    process.env.CI_PROJECT_URL = ''
-    process.env.CI_PROJECT_NAME = ''
-    process.env.CI_COMMIT_REF_NAME  = ''
-    process.env.CI_COMMIT_SHA = ''
-    process.env.CI_JOB_URL = ''
-    process.env.CI_JOB_ID = ''
-    process.env.CI_JOB_NAME = ''
-    process.env.CI_PIPELINE_SOURCE = ''
+    process.env.GITLAB_CI = '';
+    process.env.CI_PROJECT_URL = '';
+    process.env.CI_PROJECT_NAME = '';
+    process.env.CI_COMMIT_REF_NAME = '';
+    process.env.CI_COMMIT_SHA = '';
+    process.env.CI_JOB_URL = '';
+    process.env.CI_JOB_ID = '';
+    process.env.CI_JOB_NAME = '';
+    process.env.CI_PIPELINE_SOURCE = '';
     process.env.GITLAB_USER_LOGIN = '';
+
+    process.env.CIRCLECI = '';
+    process.env.CIRCLE_REPOSITORY_URL = '';
+    process.env.CIRCLE_PROJECT_REPONAME = ''; // Need to find a better match
+    process.env.CIRCLE_SHA1 = '';
+    process.env.CIRCLE_BRANCH = '';
+    process.env.CIRCLE_BUILD_URL = '';
+    process.env.CIRCLE_BUILD_NUM = '';
+    process.env.CIRCLE_JOB = '';
+    process.env.CIRCLE_USERNAME = '';
 
     process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI = '';
     process.env.BUILD_REPOSITORY_URI = '';
@@ -182,15 +192,15 @@ describe('extensions - ci-info', () => {
   });
 
   it('should send test-summary with gitlab ci information to slack', async () => {
-    process.env.GITLAB_CI=true
-    process.env.CI_PROJECT_URL = 'https://gitlab.com/testbeats/demo'
-    process.env.CI_PROJECT_NAME = 'demo'
-    process.env.CI_COMMIT_REF_NAME  = 'branch'
-    process.env.CI_COMMIT_SHA = 'sha'
-    process.env.CI_JOB_URL = 'https://gitlab.com/testbeats/demo/-/jobs/id-123'
-    process.env.CI_JOB_ID = 'id-123'
-    process.env.CI_JOB_NAME = 'Test'
-    process.env.CI_PIPELINE_SOURCE = 'push'
+    process.env.GITLAB_CI = true;
+    process.env.CI_PROJECT_URL = 'https://gitlab.com/testbeats/demo';
+    process.env.CI_PROJECT_NAME = 'demo';
+    process.env.CI_COMMIT_REF_NAME = 'branch';
+    process.env.CI_COMMIT_SHA = 'sha';
+    process.env.CI_JOB_URL = 'https://gitlab.com/testbeats/demo/-/jobs/id-123';
+    process.env.CI_JOB_ID = 'id-123';
+    process.env.CI_JOB_NAME = 'Test';
+    process.env.CI_PIPELINE_SOURCE = 'push';
     process.env.GITLAB_USER_LOGIN = 'dummy-user';
 
     const id = mock.addInteraction('post test-summary with gitlab ci-info to slack');
@@ -223,19 +233,59 @@ describe('extensions - ci-info', () => {
   });
 
   it('should send test-summary with gitlab ci information to slack - with PR', async () => {
-    process.env.GITLAB_CI=true
-    process.env.CI_OPEN_MERGE_REQUESTS='testbeats/demo!1'
-    process.env.CI_PROJECT_URL = 'https://gitlab.com/testbeats/demo'
-    process.env.CI_PROJECT_NAME = 'demo'
-    process.env.CI_COMMIT_REF_NAME  = 'branch'
-    process.env.CI_COMMIT_SHA = 'sha'
-    process.env.CI_JOB_URL = 'https://gitlab.com/testbeats/demo/-/jobs/id-123'
-    process.env.CI_JOB_ID = 'id-123'
-    process.env.CI_JOB_NAME = 'Test'
-    process.env.CI_PIPELINE_SOURCE = 'push'
+    process.env.GITLAB_CI = true;
+    process.env.CI_OPEN_MERGE_REQUESTS = 'testbeats/demo!1';
+    process.env.CI_PROJECT_URL = 'https://gitlab.com/testbeats/demo';
+    process.env.CI_PROJECT_NAME = 'demo';
+    process.env.CI_COMMIT_REF_NAME = 'branch';
+    process.env.CI_COMMIT_SHA = 'sha';
+    process.env.CI_JOB_URL = 'https://gitlab.com/testbeats/demo/-/jobs/id-123';
+    process.env.CI_JOB_ID = 'id-123';
+    process.env.CI_JOB_NAME = 'Test';
+    process.env.CI_PIPELINE_SOURCE = 'push';
     process.env.GITLAB_USER_LOGIN = 'dummy-user';
 
     const id = mock.addInteraction('post test-summary with gitlab ci-info with PR to slack');
+    await publish({
+      config: {
+        targets: [
+          {
+            name: 'slack',
+            inputs: {
+              url: 'http://localhost:9393/message'
+            },
+            extensions: [
+              {
+                name: 'ci-info'
+              }
+            ]
+          }
+        ],
+        results: [
+          {
+            type: 'testng',
+            files: [
+              'test/data/testng/single-suite.xml'
+            ]
+          }
+        ]
+      }
+    });
+    assert.equal(mock.getInteraction(id).exercised, true);
+  });
+
+  it('should send test-summary with circle-ci\'s ci information to slack', async () => {
+    process.env.CIRCLECI = true;
+    process.env.CIRCLE_REPOSITORY_URL = '';
+    process.env.CIRCLE_PROJECT_REPONAME = 'demo';
+    process.env.CIRCLE_BRANCH = 'branch';
+    process.env.CIRCLE_SHA1 = 'sja';
+    process.env.CIRCLE_BUILD_URL = 'https://apphttps://app.circleci.com/jobs/circleci/uuid-1/uuid-2';
+    process.env.CIRCLE_BUILD_NUM = 1;
+    process.env.CIRCLE_JOB = 'Test_Build';
+    process.env.CIRCLE_USERNAME = 'dummy-user@example.com';
+
+    const id = mock.addInteraction('post test-summary with circle-ci ci-info to slack');
     await publish({
       config: {
         targets: [

--- a/test/mocks/slack.mock.js
+++ b/test/mocks/slack.mock.js
@@ -793,6 +793,38 @@ addInteractionHandler('post test-summary with gitlab ci-info with PR to slack', 
   }
 });
 
+addInteractionHandler('post test-summary with circle-ci ci-info to slack', () => {
+  return {
+    request: {
+      method: 'POST',
+      path: '/message',
+      body: {
+        "attachments": [
+          {
+            "color": "#36A64F",
+            "blocks": [
+              {
+                "@DATA:TEMPLATE@": "SLACK_ROOT_SINGLE_SUITE"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Build:* <https://apphttps://app.circleci.com/jobs/circleci/uuid-1/uuid-2|Test_Build #1>"
+                }
+              }
+            ],
+            "fallback": "Default suite\nResults: 4 / 4 Passed (100%)"
+          }
+        ]
+      }
+    },
+    response: {
+      status: 200
+    }
+  }
+});
+
 addInteractionHandler('post test-summary with multiple suites and ci-info to to slack', () => {
   return {
     request: {


### PR DESCRIPTION
**Summary**
- Add `circle ci` info to  `ci-info` extensions. closes #206
- Due to limited data exposed by CircleCI in the environment variables only limited information with be printed. (Ex: Currently only build details will be printed, PR and repo/branch details won't be printed)